### PR TITLE
Cloudflare pages build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "viz",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
Pin Yarn to v1.22.22 to resolve Cloudflare Pages build failures caused by lockfile modification attempts.

Cloudflare Pages was automatically activating Yarn 4, which attempted to rewrite the existing Yarn v1 lockfile. Since Pages forbids lockfile modifications during install, this resulted in a `YN0028` error and build failure. Pinning the `packageManager` to `yarn@1.22.22` ensures the correct Yarn version is used, preventing this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-061af353-fef1-4956-bbec-e3d0d9baa2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-061af353-fef1-4956-bbec-e3d0d9baa2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

